### PR TITLE
kops state with replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ module "kops_state_backend" {
 | Name | Description |
 |------|-------------|
 | bucket_name | The name of the bucket created |
+| bucket_name_replica | The name of the replica created |

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-# TODOs
-
-- Create read-replica

--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,143 @@
 
-provider "aws" {
-  version = "~> 2.17"
-  region = var.region
+#######
+# IAM #
+#######
+
+resource "aws_iam_role" "replication" {
+  name        = "s3-replication-${var.bucket_name}"
+  description = "Allow S3 to assume the role for replication"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "s3ReplicationAssume",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
 }
 
-resource "aws_s3_bucket" "default" {
-  count         = var.create_s3_bucket ? 1 : 0
+resource "aws_iam_policy" "replication" {
+  name = "s3-replication-${var.bucket_name}"
 
-  bucket        = var.bucket_name
-  acl           = "private"
-  region        = var.region
-  force_destroy = var.force_destroy
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${var.bucket_name}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${var.bucket_name}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${var.bucket_name}-replica/*"
+    }
+  ]
+}
+POLICY
+}
 
-  versioning {
+resource "aws_iam_policy_attachment" "replication" {
+  name       = "s3-replication-${var.bucket_name}"
+  roles      = [aws_iam_role.replication.name]
+  policy_arn = aws_iam_policy.replication.arn
+}
+
+
+###########
+# Buckets #
+###########
+
+module "kops_main" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "1.18.0"
+
+  bucket = var.bucket_name
+  acl    = "private"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  versioning = {
     enabled = true
   }
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
+  replication_configuration = {
+    role = aws_iam_role.replication.arn
+
+    rules = [
+      {
+        status = "Enabled"
+
+        destination = {
+          bucket        = "arn:aws:s3:::${var.bucket_name}-replica"
+          storage_class = "STANDARD"
+        }
+      }
+    ]
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
         sse_algorithm = "AES256"
       }
     }
   }
 
-  tags = var.tags
+}
+
+module "kops_replica" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "1.18.0"
+
+  bucket = "${var.bucket_name}-replica"
+  acl    = "private"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,8 @@
 
 output "bucket_name" {
-  value = aws_s3_bucket.default.*.id
+  value = module.kops_main.this_s3_bucket_id
+}
+
+output "bucket_name_replica" {
+  value = module.kops_replica.this_s3_bucket_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS Region the S3 bucket should reside in"
-  default     = "eu-west-2"
-}
-
 variable "create_s3_bucket" {
   type        = bool
   default     = true


### PR DESCRIPTION
The main improvement/change is support for replica buckets (for kops state). Also deleted the provider configuration within the module (it should be outside in the definition)

Another change:

- Region shouldn't be a variable because provider configuration happens in the definition side - not within the module itself.
- Added s3 bucket replica output